### PR TITLE
Optimizations

### DIFF
--- a/CS3243_P2_Sudoku_01.py
+++ b/CS3243_P2_Sudoku_01.py
@@ -30,26 +30,33 @@ class Sudoku(object):
         squareMissingN = copy.deepcopy(rowMissingN)
         # numbers = [1, 2, 3, 4, 5, 6, 7, 8, 9]
         
-        # self.possibleValues = [[[[True] * 10] * 9] * 9]
+        self.domains = [[[True] * 10 for i in range(9)] for j in range(9)]
         self.constraintChecks = [rowMissingN, colMissingN, squareMissingN]
         self.numAssignCount = [0] * 10
+
+        # print(len(self.domains))
+        # print(len(self.domains[0]))
+        # print(len(self.domains[0][0]))
 
         for i in range(9):
             for j in range(9):
                 curr = self.ans[i][j]
 
                 if curr != 0:
-                    squareNum = self.getSquareNum(i, j)
+                    # print("assigning: " + str(curr))
+                    self.assign((i, j, []), curr)
+                    # squareNum = self.getSquareNum(i, j)
 
-                    rowMissingN[i][curr] = False
-                    colMissingN[j][curr] = False
-                    squareMissingN[squareNum][curr] = False
-                    self.numAssignCount[curr] += 1
-                    # self.possibleValues[i][j] = [[False] * 10]
-                    # self.possibleValues[i][j][curr] = True
+                    # rowMissingN[i][curr] = False
+                    # colMissingN[j][curr] = False
+                    # squareMissingN[squareNum][curr] = False
+                    # self.numAssignCount[curr] += 1
+                    # self.domains[i][j] = [False] * 10
+                    # self.domains[i][j][curr] = True
 
     def getSquareNum(self, i, j):
-        return int(math.floor(i/3) + math.floor(j/3) * 3)
+        # return int(math.floor(i/3) + math.floor(j/3) * 3)
+        return i // 3 + (j // 3) * 3
 
     def backtrack(self):
         var = self.getUnassignedVariable()
@@ -101,16 +108,22 @@ class Sudoku(object):
         return returnVariable
 
     def getDomain(self, i, j):
-        rowMissingN = self.constraintChecks[0][i]
-        colMissingN = self.constraintChecks[1][j]
-        squareMissingN = self.constraintChecks[2][self.getSquareNum(i, j)]
-
         domain = []
         for num in range(1, 10):
-            if rowMissingN[num] and colMissingN[num] and squareMissingN[num]:
+            if (self.domains[i][j][num]):
                 domain.append(num)
-
         return domain
+
+        # rowMissingN = self.constraintChecks[0][i]
+        # colMissingN = self.constraintChecks[1][j]
+        # squareMissingN = self.constraintChecks[2][self.getSquareNum(i, j)]
+
+        # domain = []
+        # for num in range(1, 10):
+        #     if rowMissingN[num] and colMissingN[num] and squareMissingN[num]:
+        #         domain.append(num)
+
+        # return domain
 
     # using least constraining value heuristic
     # get domain in the order of least constraining to most constraining
@@ -132,6 +145,22 @@ class Sudoku(object):
         squareMissingN[num] = False
         self.numAssignCount[num] = self.numAssignCount[num] + 1
 
+        self.infer(var, num)
+
+    def infer(self, var, num):
+        i, j, domain = var
+        for c in range(9):
+            self.domains[i][c][num] = False
+
+        for r in range(9):
+            self.domains[r][j][num] = False
+
+        bigRow = i // 3
+        bigCol = j // 3
+        for r in range(3):
+            for c in range(3):
+                self.domains[r + bigRow][c + bigCol][num] = False
+
     def unassign(self, var, num):
         i, j, domain = var
         rowMissingN = self.constraintChecks[0][i]
@@ -143,6 +172,32 @@ class Sudoku(object):
         colMissingN[num] = True
         squareMissingN[num] = True
         self.numAssignCount[num] = self.numAssignCount[num] - 1
+
+        self.uninfer(var, num)
+
+    def uninfer(self, var, num):
+        i, j, domain = var
+        rowMissingN = self.constraintChecks[0][i]
+        colMissingN = self.constraintChecks[1][j]
+        squareMissingN = self.constraintChecks[2][self.getSquareNum(i, j)]
+
+        for c in range(9):
+            if not colMissingN[num]:
+                self.domains[i][c][num] = True
+
+        for r in range(9):
+            if not rowMissingN[num]:
+                self.domains[r][j][num] = True
+
+        bigRow = i // 3
+        bigCol = j // 3
+        squareNum = self.getSquareNum(i, j)
+        if not squareMissingN[num]:
+            for r in range(3):
+                for c in range(3):
+                    self.domains[r + bigRow][c + bigCol][num] = True
+
+        
         
 if __name__ == "__main__":
     # STRICTLY do NOT modify the code in the main function here

--- a/CS3243_P2_Sudoku_01.py
+++ b/CS3243_P2_Sudoku_01.py
@@ -22,21 +22,16 @@ class Sudoku(object):
 
         if self.backtrack():
             return self.ans
+        
         return "Sudoku cannot be solved."
 
     def initDataStructure(self):
         rowMissingN = [[True] * 10 for i in range(9)]
         colMissingN = copy.deepcopy(rowMissingN)
         squareMissingN = copy.deepcopy(rowMissingN)
-        # numbers = [1, 2, 3, 4, 5, 6, 7, 8, 9]
         
-        self.domains = [[[True] * 10 for i in range(9)] for j in range(9)]
         self.constraintChecks = [rowMissingN, colMissingN, squareMissingN]
         self.numAssignCount = [0] * 10
-
-        # print(len(self.domains))
-        # print(len(self.domains[0]))
-        # print(len(self.domains[0][0]))
 
         for i in range(9):
             for j in range(9):
@@ -45,17 +40,8 @@ class Sudoku(object):
                 if curr != 0:
                     # print("assigning: " + str(curr))
                     self.assign((i, j, []), curr)
-                    # squareNum = self.getSquareNum(i, j)
-
-                    # rowMissingN[i][curr] = False
-                    # colMissingN[j][curr] = False
-                    # squareMissingN[squareNum][curr] = False
-                    # self.numAssignCount[curr] += 1
-                    # self.domains[i][j] = [False] * 10
-                    # self.domains[i][j][curr] = True
-
+                    
     def getSquareNum(self, i, j):
-        # return int(math.floor(i/3) + math.floor(j/3) * 3)
         return i // 3 + (j // 3) * 3
 
     def backtrack(self):
@@ -69,8 +55,6 @@ class Sudoku(object):
         domain = self.getSortedDomain(var)
         for num in domain:
             self.assign(var, num)
-            # inference = self.infer(var)
-            # if inference != False:
 
             if self.backtrack():
                 return True
@@ -108,22 +92,15 @@ class Sudoku(object):
         return returnVariable
 
     def getDomain(self, i, j):
+        rowMissingN = self.constraintChecks[0][i]
+        colMissingN = self.constraintChecks[1][j]
+        squareMissingN = self.constraintChecks[2][self.getSquareNum(i, j)]
+
         domain = []
         for num in range(1, 10):
-            if (self.domains[i][j][num]):
+            if rowMissingN[num] and colMissingN[num] and squareMissingN[num]:
                 domain.append(num)
         return domain
-
-        # rowMissingN = self.constraintChecks[0][i]
-        # colMissingN = self.constraintChecks[1][j]
-        # squareMissingN = self.constraintChecks[2][self.getSquareNum(i, j)]
-
-        # domain = []
-        # for num in range(1, 10):
-        #     if rowMissingN[num] and colMissingN[num] and squareMissingN[num]:
-        #         domain.append(num)
-
-        # return domain
 
     # using least constraining value heuristic
     # get domain in the order of least constraining to most constraining
@@ -145,22 +122,6 @@ class Sudoku(object):
         squareMissingN[num] = False
         self.numAssignCount[num] = self.numAssignCount[num] + 1
 
-        self.infer(var, num)
-
-    def infer(self, var, num):
-        i, j, domain = var
-        for c in range(9):
-            self.domains[i][c][num] = False
-
-        for r in range(9):
-            self.domains[r][j][num] = False
-
-        bigRow = i // 3
-        bigCol = j // 3
-        for r in range(3):
-            for c in range(3):
-                self.domains[r + bigRow][c + bigCol][num] = False
-
     def unassign(self, var, num):
         i, j, domain = var
         rowMissingN = self.constraintChecks[0][i]
@@ -172,30 +133,6 @@ class Sudoku(object):
         colMissingN[num] = True
         squareMissingN[num] = True
         self.numAssignCount[num] = self.numAssignCount[num] - 1
-
-        self.uninfer(var, num)
-
-    def uninfer(self, var, num):
-        i, j, domain = var
-        rowMissingN = self.constraintChecks[0][i]
-        colMissingN = self.constraintChecks[1][j]
-        squareMissingN = self.constraintChecks[2][self.getSquareNum(i, j)]
-
-        for c in range(9):
-            if not colMissingN[num]:
-                self.domains[i][c][num] = True
-
-        for r in range(9):
-            if not rowMissingN[num]:
-                self.domains[r][j][num] = True
-
-        bigRow = i // 3
-        bigCol = j // 3
-        squareNum = self.getSquareNum(i, j)
-        if not squareMissingN[num]:
-            for r in range(3):
-                for c in range(3):
-                    self.domains[r + bigRow][c + bigCol][num] = True
 
         
         

--- a/CS3243_P2_Sudoku_01.py
+++ b/CS3243_P2_Sudoku_01.py
@@ -53,45 +53,48 @@ class Sudoku(object):
                 else:
                     self.unassigned.add((i, j))
                     
-    def getSquareNum(self, i, j):
-        return self.squareRef[i][j]
+    # def getSquareNum(self, i, j): # migrated; unused
+    #     return self.squareRef[i][j]
 
     def backtrack(self):
+        domainOrder = range(1, 10)
+        domainOrder.sort(key = lambda x: self.numAssignCount[x])
 
         # getUnassignedVariable
         minDomainSize = 99
         var = None
-        for pair in self.unassigned:
-            i, j = pair
-            curr = self.ans[i][j]
+        for i, j in self.unassigned:
             rowMissingN = self.constraintChecks[0][i]
             colMissingN = self.constraintChecks[1][j]
             squareMissingN = self.constraintChecks[2][self.squareRef[i][j]]
 
             domain = []
-            for num in range(1, 10):
+            for num in domainOrder:
                 if rowMissingN[num] and colMissingN[num] and squareMissingN[num]:
                     domain.append(num)
             domainSize = len(domain)
 
-            if domainSize == 0:
+            if domainSize >= minDomainSize:
+                continue
+            elif domainSize == 0:
                 return False
-
             elif domainSize == 1:
                 var = (i, j, domain)
                 break
             else:
-                if domainSize < minDomainSize:
-                    var = (i, j, domain)
-                    minDomainSize = domainSize
+                var = (i, j, domain)
+                minDomainSize = domainSize
 
-        var[2].sort(key = lambda x: self.numAssignCount[x])
+        if var is None:
+            return True
+
         i, j, domain = var
+        domain.sort(key = lambda x: self.numAssignCount[x])
         rowMissingN = self.constraintChecks[0][i]
         colMissingN = self.constraintChecks[1][j]
         squareMissingN = self.constraintChecks[2][self.squareRef[i][j]]
         self.unassigned.remove((i, j))
-        for num in var[2]:
+        for num in domain:
             # assign
             self.ans[i][j] = num
             rowMissingN[num] = False
@@ -99,7 +102,7 @@ class Sudoku(object):
             squareMissingN[num] = False
             self.numAssignCount[num] = self.numAssignCount[num] + 1
             # backtracking
-            if len(self.unassigned) == 0 or self.backtrack():
+            if self.backtrack():
                 return True
             # unassign
             rowMissingN[num] = True
@@ -112,98 +115,98 @@ class Sudoku(object):
 
     # using the minimum remaining value heuristic
     # get the cell with the minimum domain size
-    def getUnassignedVariable(self): # migrated; unused
-        minDomainSize = 99
-        returnVariable = None
+    # def getUnassignedVariable(self): # migrated; unused
+    #     minDomainSize = 99
+    #     returnVariable = None
 
-        for pair in self.unassigned:
-            i, j = pair
-            curr = self.ans[i][j]
+    #     for pair in self.unassigned:
+    #         i, j = pair
+    #         curr = self.ans[i][j]
 
-            if curr != 0:
-                continue
+    #         if curr != 0:
+    #             continue
 
-            rowMissingN = self.constraintChecks[0][i]
-            colMissingN = self.constraintChecks[1][j]
-            squareMissingN = self.constraintChecks[2][self.getSquareNum(i, j)]
+    #         rowMissingN = self.constraintChecks[0][i]
+    #         colMissingN = self.constraintChecks[1][j]
+    #         squareMissingN = self.constraintChecks[2][self.getSquareNum(i, j)]
 
-            domain = []
-            for num in range(1, 10):
-                if rowMissingN[num] and colMissingN[num] and squareMissingN[num]:
-                    domain.append(num)
-            domainSize = len(domain)
+    #         domain = []
+    #         for num in range(1, 10):
+    #             if rowMissingN[num] and colMissingN[num] and squareMissingN[num]:
+    #                 domain.append(num)
+    #         domainSize = len(domain)
 
-            if domainSize == 0:
-                return False
+    #         if domainSize == 0:
+    #             return False
 
-            elif domainSize == 1:
-                return (i, j, domain)
+    #         elif domainSize == 1:
+    #             return (i, j, domain)
 
-            else:
-                if domainSize < minDomainSize:
-                    returnVariable = (i, j, domain)
-                    minDomainSize = domainSize
+    #         else:
+    #             if domainSize < minDomainSize:
+    #                 returnVariable = (i, j, domain)
+    #                 minDomainSize = domainSize
 
 
-        return returnVariable
+    #     return returnVariable
 
-    def getDomain(self, i, j): # migrated; unused
-        rowMissingN = self.constraintChecks[0][i]
-        colMissingN = self.constraintChecks[1][j]
-        squareMissingN = self.constraintChecks[2][self.getSquareNum(i, j)]
+    # def getDomain(self, i, j): # migrated; unused
+    #     rowMissingN = self.constraintChecks[0][i]
+    #     colMissingN = self.constraintChecks[1][j]
+    #     squareMissingN = self.constraintChecks[2][self.getSquareNum(i, j)]
 
-        domain = []
-        for num in range(1, 10):
-            if rowMissingN[num] and colMissingN[num] and squareMissingN[num]:
-                domain.append(num)
-        return domain
+    #     domain = []
+    #     for num in range(1, 10):
+    #         if rowMissingN[num] and colMissingN[num] and squareMissingN[num]:
+    #             domain.append(num)
+    #     return domain
 
     # using least constraining value heuristic
     # get domain in the order of least constraining to most constraining
     # least constraining value is the number that has been assigned the least
-    def getSortedDomain(self, var): # migrated; unused
-        originalDomain = var[2]
-        originalDomain.sort(key = lambda x: self.numAssignCount[x])
-        return originalDomain
+    # def getSortedDomain(self, var): # migrated; unused
+    #     originalDomain = var[2]
+    #     originalDomain.sort(key = lambda x: self.numAssignCount[x])
+    #     return originalDomain
 
-    def assign(self, var, num): # migrated; unused
-        i, j, domain = var
-        rowMissingN = self.constraintChecks[0][i]
-        colMissingN = self.constraintChecks[1][j]
-        squareMissingN = self.constraintChecks[2][self.getSquareNum(i, j)]
+    # def assign(self, var, num): # migrated; unused
+    #     i, j, domain = var
+    #     rowMissingN = self.constraintChecks[0][i]
+    #     colMissingN = self.constraintChecks[1][j]
+    #     squareMissingN = self.constraintChecks[2][self.getSquareNum(i, j)]
 
-        self.ans[i][j] = num
-        self.unassigned.remove((i, j))
-        rowMissingN[num] = False
-        colMissingN[num] = False
-        squareMissingN[num] = False
-        self.numAssignCount[num] = self.numAssignCount[num] + 1
+    #     self.ans[i][j] = num
+    #     self.unassigned.remove((i, j))
+    #     rowMissingN[num] = False
+    #     colMissingN[num] = False
+    #     squareMissingN[num] = False
+    #     self.numAssignCount[num] = self.numAssignCount[num] + 1
     
-    def assignInit(self, var, num): # migrated; unused
-        # same as assign but without the self.unassigned removal
-        i, j, domain = var
-        rowMissingN = self.constraintChecks[0][i]
-        colMissingN = self.constraintChecks[1][j]
-        squareMissingN = self.constraintChecks[2][self.getSquareNum(i, j)]
+    # def assignInit(self, var, num): # migrated; unused
+    #     # same as assign but without the self.unassigned removal
+    #     i, j, domain = var
+    #     rowMissingN = self.constraintChecks[0][i]
+    #     colMissingN = self.constraintChecks[1][j]
+    #     squareMissingN = self.constraintChecks[2][self.getSquareNum(i, j)]
 
-        self.ans[i][j] = num
-        rowMissingN[num] = False
-        colMissingN[num] = False
-        squareMissingN[num] = False
-        self.numAssignCount[num] = self.numAssignCount[num] + 1
+    #     self.ans[i][j] = num
+    #     rowMissingN[num] = False
+    #     colMissingN[num] = False
+    #     squareMissingN[num] = False
+    #     self.numAssignCount[num] = self.numAssignCount[num] + 1
 
-    def unassign(self, var, num): # migrated, unused
-        i, j, domain = var
-        rowMissingN = self.constraintChecks[0][i]
-        colMissingN = self.constraintChecks[1][j]
-        squareMissingN = self.constraintChecks[2][self.getSquareNum(i, j)]
+    # def unassign(self, var, num): # migrated, unused
+    #     i, j, domain = var
+    #     rowMissingN = self.constraintChecks[0][i]
+    #     colMissingN = self.constraintChecks[1][j]
+    #     squareMissingN = self.constraintChecks[2][self.getSquareNum(i, j)]
 
-        self.ans[i][j] = 0
-        self.unassigned.add((i, j))
-        rowMissingN[num] = True
-        colMissingN[num] = True
-        squareMissingN[num] = True
-        self.numAssignCount[num] = self.numAssignCount[num] - 1
+    #     self.ans[i][j] = 0
+    #     self.unassigned.add((i, j))
+    #     rowMissingN[num] = True
+    #     colMissingN[num] = True
+    #     squareMissingN[num] = True
+    #     self.numAssignCount[num] = self.numAssignCount[num] - 1
 
         
         

--- a/CS3243_P2_Sudoku_01.py
+++ b/CS3243_P2_Sudoku_01.py
@@ -27,11 +27,12 @@ class Sudoku(object):
 
     def initDataStructure(self):
         rowMissingN = [[True] * 10 for i in range(9)]
-        colMissingN = copy.deepcopy(rowMissingN)
-        squareMissingN = copy.deepcopy(rowMissingN)
+        colMissingN = [[True] * 10 for i in range(9)]
+        squareMissingN = [[True] * 10 for i in range(9)]
         
         self.constraintChecks = [rowMissingN, colMissingN, squareMissingN]
         self.numAssignCount = [0] * 10
+        self.unassigned = set()
 
         for i in range(9):
             for j in range(9):
@@ -39,7 +40,9 @@ class Sudoku(object):
 
                 if curr != 0:
                     # print("assigning: " + str(curr))
-                    self.assign((i, j, []), curr)
+                    self.assignInit((i, j, []), curr)
+                else:
+                    self.unassigned.add((i, j))
                     
     def getSquareNum(self, i, j):
         return i // 3 + (j // 3) * 3
@@ -52,8 +55,8 @@ class Sudoku(object):
         elif var == False:
             return False
 
-        domain = self.getSortedDomain(var)
-        for num in domain:
+        var[2].sort(key = lambda x: self.numAssignCount[x])
+        for num in var[2]:
             self.assign(var, num)
 
             if self.backtrack():
@@ -67,26 +70,26 @@ class Sudoku(object):
         minDomainSize = 99
         returnVariable = None
 
-        for i in range(9):
-            for j in range(9):
-                curr = self.ans[i][j]
+        for pair in self.unassigned:
+            i, j = pair
+            curr = self.ans[i][j]
 
-                if curr != 0:
-                    continue
+            if curr != 0:
+                continue
 
-                domain = self.getDomain(i, j)
-                domainSize = len(domain)
+            domain = self.getDomain(i, j)
+            domainSize = len(domain)
 
-                if domainSize == 0:
-                    return False
+            if domainSize == 0:
+                return False
 
-                elif domainSize == 1:
-                    return (i, j, domain)
+            elif domainSize == 1:
+                return (i, j, domain)
 
-                else:
-                    if domainSize < minDomainSize:
-                        returnVariable = (i, j, domain)
-                        minDomainSize = domainSize
+            else:
+                if domainSize < minDomainSize:
+                    returnVariable = (i, j, domain)
+                    minDomainSize = domainSize
 
 
         return returnVariable
@@ -117,6 +120,20 @@ class Sudoku(object):
         squareMissingN = self.constraintChecks[2][self.getSquareNum(i, j)]
 
         self.ans[i][j] = num
+        self.unassigned.remove((i, j))
+        rowMissingN[num] = False
+        colMissingN[num] = False
+        squareMissingN[num] = False
+        self.numAssignCount[num] = self.numAssignCount[num] + 1
+    
+    def assignInit(self, var, num):
+        # same as assign but without the self.unassigned removal
+        i, j, domain = var
+        rowMissingN = self.constraintChecks[0][i]
+        colMissingN = self.constraintChecks[1][j]
+        squareMissingN = self.constraintChecks[2][self.getSquareNum(i, j)]
+
+        self.ans[i][j] = num
         rowMissingN[num] = False
         colMissingN[num] = False
         squareMissingN[num] = False
@@ -129,6 +146,7 @@ class Sudoku(object):
         squareMissingN = self.constraintChecks[2][self.getSquareNum(i, j)]
 
         self.ans[i][j] = 0
+        self.unassigned.add((i, j))
         rowMissingN[num] = True
         colMissingN[num] = True
         squareMissingN[num] = True


### PR DESCRIPTION
- **Use a set to check unassigned variables** (expressed as a pair), initialized and then maintained on assign/unassign
- Migrate frequently used helper functions into the main algorithm to reduce method overhead
  - Only exception is `backtrack`, can consider migrating to a stack as well
- Use a constant data structure (e.g. `squareRef`) in place of performing repeated operations

Runtime is now fast for all inputs except Input 1:
![image](https://user-images.githubusercontent.com/53135010/96641274-0f9d9480-1357-11eb-9c59-c814aabbb364.png)

This has been the case ever since a set was used to check pairs. Suspect that this is due to a large number of unassigned pairs maintained inside for a long time.