### PR TITLE
Further optimizations

### DIFF
--- a/CS3243_P2_Sudoku_01.py
+++ b/CS3243_P2_Sudoku_01.py
@@ -51,7 +51,7 @@ class Sudoku(object):
                     squareMissingN[num] = False
                     self.numAssignCount[num] = self.numAssignCount[num] + 1
                 else:
-                    self.unassigned.add((i, j))
+                    self.unassigned.add((i, j, i + 9 * j))
                     
     # def getSquareNum(self, i, j): # migrated; unused
     #     return self.squareRef[i][j]
@@ -63,7 +63,7 @@ class Sudoku(object):
         # getUnassignedVariable
         minDomainSize = 99
         var = None
-        for i, j in self.unassigned:
+        for i, j, unused in self.unassigned:
             rowMissingN = self.constraintChecks[0][i]
             colMissingN = self.constraintChecks[1][j]
             squareMissingN = self.constraintChecks[2][self.squareRef[i][j]]
@@ -93,7 +93,7 @@ class Sudoku(object):
         rowMissingN = self.constraintChecks[0][i]
         colMissingN = self.constraintChecks[1][j]
         squareMissingN = self.constraintChecks[2][self.squareRef[i][j]]
-        self.unassigned.remove((i, j))
+        self.unassigned.remove((i, j, i + 9 * j))
         for num in domain:
             # assign
             self.ans[i][j] = num
@@ -111,7 +111,7 @@ class Sudoku(object):
             self.numAssignCount[num] = self.numAssignCount[num] - 1
 
         self.ans[i][j] = 0
-        self.unassigned.add((i, j))
+        self.unassigned.add((i, j, i + 9 * j))
 
     # using the minimum remaining value heuristic
     # get the cell with the minimum domain size

--- a/CS3243_P2_Sudoku_01.py
+++ b/CS3243_P2_Sudoku_01.py
@@ -14,8 +14,8 @@ import math
 # each square only have one instance of 1..9
 class Sudoku(object):
     def __init__(self, puzzle):
-        self.puzzle = puzzle  # self.puzzle is a list of lists
-        self.ans = copy.deepcopy(puzzle)  # self.ans is a list of lists
+        # self.puzzle = puzzle  # self.puzzle is a list of lists
+        self.ans = puzzle  # self.ans is a list of lists
 
     def solve(self):
         self.initDataStructure()


### PR DESCRIPTION
- Remove deep copy from `self.puzzle` as we no longer require two copies
- **Add additional data to the tuples representing unassigned variables** in `self.unassigned`.
  - I believe this might be somehow due to the hashing of the tuple affecting the performance of the set.
  - This speeds up Input 1, at the cost of doubling the time of Input 4 (but still well within the 10 seconds bound).

![image](https://user-images.githubusercontent.com/53135010/96715671-8463e380-13d6-11eb-9b6b-22f9961813f6.png)
